### PR TITLE
feat(pos): Operationalize POS and Store management

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuth } from "@/hooks/use-auth";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { useEffect } from "react";
 import { Loader2 } from "lucide-react";
 import DashboardSidebar from "@/components/dashboard/DashboardSidebar";
@@ -16,15 +16,33 @@ export default function DashboardLayout({
 }) {
   const { user, isAuthenticated, isEmployee, isLoading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
   useActivityRefresh();
 
   useEffect(() => {
     if (!isLoading) {
       if (!isAuthenticated || !isEmployee) {
         router.push("/staff");
+        return;
+      }
+
+      // Route Authorization
+      const userRole = user?.role || "CASHIER";
+      
+      // If user is a CASHIER, restrict their access to specific allowed paths only
+      if (userRole === "CASHIER") {
+        const allowedPaths = ["/dashboard", "/dashboard/pos"];
+        // Allow exact matches or sub-paths like /dashboard/pos/...
+        const isAllowed = allowedPaths.some(
+          allowed => pathname === allowed || pathname.startsWith(`${allowed}/`)
+        );
+        
+        if (!isAllowed) {
+          router.push("/dashboard");
+        }
       }
     }
-  }, [isLoading, isAuthenticated, isEmployee, router]);
+  }, [isLoading, isAuthenticated, isEmployee, router, pathname, user]);
 
   if (isLoading || !isAuthenticated || !isEmployee) {
     return (

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useAuth } from "@/hooks/use-auth";
 import { cn } from "@/lib/utils";
 import { 
   LayoutDashboard, 
@@ -19,18 +20,22 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
 const navItems = [
-  { name: "Overview", href: "/dashboard", icon: LayoutDashboard },
-  { name: "Pos (Kasir)", href: "/dashboard/pos", icon: ShoppingCart },
-  { name: "Products", href: "/dashboard/products", icon: Package },
-  { name: "Purchases", href: "/dashboard/purchases", icon: ShoppingBag },
-  { name: "Repacks", href: "/dashboard/repacks", icon: Scissors },
-  { name: "Stock Ledger", href: "/dashboard/stock", icon: Activity },
-  { name: "Logs", href: "/dashboard/logs", icon: ClipboardList },
+  { name: "Overview", href: "/dashboard", icon: LayoutDashboard, roles: ["MANAGER", "CASHIER"] },
+  { name: "Pos (Kasir)", href: "/dashboard/pos", icon: ShoppingCart, roles: ["MANAGER", "CASHIER"] },
+  { name: "Products", href: "/dashboard/products", icon: Package, roles: ["MANAGER"] },
+  { name: "Purchases", href: "/dashboard/purchases", icon: ShoppingBag, roles: ["MANAGER"] },
+  { name: "Repacks", href: "/dashboard/repacks", icon: Scissors, roles: ["MANAGER"] },
+  { name: "Stock Ledger", href: "/dashboard/stock", icon: Activity, roles: ["MANAGER"] },
+  { name: "Logs", href: "/dashboard/logs", icon: ClipboardList, roles: ["MANAGER"] },
 ];
 
 export default function DashboardSidebar() {
   const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
+  const { user } = useAuth();
+  
+  const userRole = user?.role || "CASHIER";
+  const filteredNavItems = navItems.filter(item => item.roles.includes(userRole));
 
   return (
     <>
@@ -72,7 +77,7 @@ export default function DashboardSidebar() {
 
           {/* Navigation Links */}
           <nav className="flex-1 overflow-y-auto py-6 px-4 space-y-1">
-            {navItems.map((item) => {
+            {filteredNavItems.map((item) => {
               const isActive = pathname === item.href;
               return (
                 <Link

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -25,12 +25,14 @@ const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001';
 export class ApiError extends Error {
   statusCode: number;
   response?: ApiResponse<unknown>;
+  url?: string;
 
-  constructor(message: string, statusCode: number, response?: ApiResponse<unknown>) {
+  constructor(message: string, statusCode: number, response?: ApiResponse<unknown>, url?: string) {
     super(message);
     this.name = 'ApiError';
     this.statusCode = statusCode;
     this.response = response;
+    this.url = url;
   }
 }
 
@@ -116,7 +118,9 @@ async function fetchApi<T>(endpoint: string, options: RequestInit = {}): Promise
             const retryResponse = await makeRequest(newToken);
             const result = await retryResponse.json();
             if (!retryResponse.ok) {
-              reject(new ApiError(result.message || 'Retry failed', retryResponse.status, result));
+              const errorMsg = `[${retryResponse.status}] ${options.method || "GET"} ${url}: ${result.message || "Forbidden"}`;
+              console.warn(errorMsg, result);
+              reject(new ApiError(errorMsg, retryResponse.status, result, url));
             } else {
               resolve(result);
             }
@@ -131,7 +135,9 @@ async function fetchApi<T>(endpoint: string, options: RequestInit = {}): Promise
   const result = await response.json();
 
   if (!response.ok) {
-    throw new ApiError(result.message || `API request failed at ${url}`, response.status, result);
+    const errorMsg = `[${response.status}] ${options.method || 'GET'} ${url}: ${result.message || 'Forbidden'}`;
+    console.warn(errorMsg, result);
+    throw new ApiError(errorMsg, response.status, result, url);
   }
 
   return result as ApiResponse<T>;


### PR DESCRIPTION
Closes #3. 

### What was done:
- POS checkout now uses the real backend API (`/orders`) and correctly triggers the Stock Ledger pattern on the backend.
- Fixed the `DashboardHeader` store status toggle (Open/Close) to persist to the backend without React state bugs.
- Fixed 403 Forbidden errors when Cashier users navigated to restricted pages, including robust route-level protection in the dashboard layout.
- Added deep API logging for easier future debugging.
- Removed hard reloads in the POS flow, substituting with targeted state refetches.