### PR TITLE
feat(dashboard): implement server-side search for all list pages

### DIFF
--- a/src/app/(dashboard)/dashboard/consignment/page.tsx
+++ b/src/app/(dashboard)/dashboard/consignment/page.tsx
@@ -3,44 +3,8 @@
 import { useState, useEffect, useMemo } from "react";
 import { toast } from "sonner";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { 
-  Handshake, 
-  Plus, 
-  Search, 
-  MoreVertical,
-  Edit2,
-  Trash2,
-  Package,
-  ChevronRight,
-  Info,
-  ArrowRight,
-  Store,
-  Calendar,
-  CircleAlert,
-  CircleCheck,
-  Calculator,
-  CircleX,
-  Clock
-} from "lucide-react";
-import { 
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from "@/components/ui/table";
 import { cn } from "@/lib/utils";
-import { Badge } from "@/components/ui/badge";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  DropdownMenuLabel,
-} from "@/components/ui/dropdown-menu";
+import { Calculator, CircleCheck, Clock } from "lucide-react";
 import { ConsignmentForm } from "@/components/dashboard/consignment/ConsignmentForm";
 import { SettlementView } from "@/components/dashboard/consignment/SettlementView";
 import { ConsignmentDataList } from "@/components/dashboard/consignment/ConsignmentDataList";
@@ -50,28 +14,39 @@ import { Consignment } from "@/types/financial";
 
 type ViewState = "list" | "settle" | "detail";
 
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
 export default function ConsignmentPage() {
   const [view, setView] = useState<ViewState>("list");
   const [consignments, setConsignments] = useState<Consignment[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedConsignment, setSelectedConsignment] = useState<Consignment | null>(null);
-
-  const fetchConsignments = async () => {
-    setIsLoading(true);
-    try {
-      const { data } = await api.consignment.list();
-      setConsignments(data);
-    } catch (error: unknown) {
-      console.error("Failed to fetch consignments", error);
-      toast.error("Gagal memuat daftar konsinyasi.");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
 
   useEffect(() => {
-    fetchConsignments();
-  }, []);
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const { data } = await api.consignment.list(debouncedSearch || undefined);
+        if (!cancelled) setConsignments(data);
+      } catch (error: unknown) {
+        console.error("Failed to fetch consignments", error);
+        toast.error("Gagal memuat daftar konsinyasi.");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+    void load();
+    return () => { cancelled = true; };
+  }, [debouncedSearch]);
 
   const stats = useMemo(() => {
     const active = consignments.filter(c => c.status !== 'CLOSED').length;
@@ -91,7 +66,12 @@ export default function ConsignmentPage() {
         onSuccess={() => {
           setView("list");
           setSelectedConsignment(null);
-          fetchConsignments();
+          api.consignment.list(debouncedSearch || undefined)
+            .then(({ data }) => setConsignments(data))
+            .catch((error: unknown) => {
+              console.error("Failed to fetch consignments", error);
+              toast.error("Gagal memuat daftar konsinyasi.");
+            });
         }} 
       />
     );
@@ -202,7 +182,12 @@ export default function ConsignmentPage() {
         <div className="pb-4">
           <ConsignmentForm 
             onSuccess={() => {
-              fetchConsignments();
+              api.consignment.list(debouncedSearch || undefined)
+                .then(({ data }) => setConsignments(data))
+                .catch((error: unknown) => {
+                  console.error("Failed to fetch consignments", error);
+                  toast.error("Gagal memuat daftar konsinyasi.");
+                });
               document.getElementById("history")?.scrollIntoView({ behavior: 'smooth' });
             }} 
           />
@@ -212,6 +197,8 @@ export default function ConsignmentPage() {
         <ConsignmentDataList 
           consignments={consignments}
           isLoading={isLoading}
+          search={search}
+          onSearchChange={setSearch}
           onSettle={(c) => {
             setSelectedConsignment(c);
             setView("settle");

--- a/src/app/(dashboard)/dashboard/pos/page.tsx
+++ b/src/app/(dashboard)/dashboard/pos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef, useMemo } from "react";
+import { useEffect, useState, useRef, useMemo, useCallback } from "react";
 import { toast } from "sonner";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { getProductsFromDb } from "@/lib/products-db";
@@ -39,19 +39,29 @@ interface CartItem extends DisplayVariant {
   quantity: number;
 }
 
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
 export default function POSPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearch = useDebounce(searchQuery, 300);
   const [cart, setCart] = useState<CartItem[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const isInternalReload = useRef(false);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
 
-  const fetchProducts = async () => {
+  const fetchProducts = useCallback(async (search?: string) => {
     setIsLoading(true);
     try {
-      const { data } = await getProductsFromDb(1, 100);
+      const { data } = await getProductsFromDb(1, 100, undefined, search);
       setProducts(data);
     } catch (error) {
       console.error("Failed to fetch products:", error);
@@ -59,11 +69,11 @@ export default function POSPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    fetchProducts();
-  }, []);
+    fetchProducts(debouncedSearch || undefined);
+  }, [debouncedSearch, fetchProducts]);
 
   // Transform products into a flat list of variants for display
   const displayVariants = useMemo(() => {
@@ -83,7 +93,6 @@ export default function POSPage() {
     return variants;
   }, [products]);
 
-  // Prevent accidental page reload if there are items in cart or checkout is in progress
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (isInternalReload.current) return;
@@ -97,11 +106,6 @@ export default function POSPage() {
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [isProcessing, cart.length]);
-
-  const filteredVariants = displayVariants.filter(v => 
-    v.productName.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    v.package.toLowerCase().includes(searchQuery.toLowerCase())
-  );
 
   const addToCart = (variant: DisplayVariant) => {
     const existing = cart.find(item => item.id === variant.id);
@@ -222,7 +226,7 @@ export default function POSPage() {
             />
           ) : (
             <div className="grid grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4">
-              {filteredVariants.map((p) => (
+              {displayVariants.map((p) => (
                 <Card 
                   key={p.id} 
                   className="cursor-pointer hover:border-primary/50 transition-all duration-300 group active:scale-95 shadow-sm border-gray-200/50 dark:border-gray-800/50 rounded-3xl bg-white/80 dark:bg-gray-950/80 backdrop-blur-xl hover:shadow-xl hover:shadow-primary/5 min-h-[140px]"

--- a/src/app/(dashboard)/dashboard/products/page.tsx
+++ b/src/app/(dashboard)/dashboard/products/page.tsx
@@ -20,24 +20,33 @@ import { cn } from "@/lib/utils";
 import { ProductCreateDialog } from "@/components/dashboard/products/ProductCreateDialog";
 import { Badge } from "@/components/ui/badge";
 
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
 export default function DashboardProductsPage() {
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 300);
 
   useEffect(() => {
-    async function fetchProducts() {
-      setIsLoading(true);
-      const { data } = await getProductsFromDb(1, 100);
-      setProducts(data);
-      setIsLoading(false);
-    }
-    fetchProducts();
-  }, []);
-
-  const filteredProducts = products.filter(p => 
-    p.name.toLowerCase().includes(searchTerm.toLowerCase())
-  );
+    let cancelled = false;
+    const load = async () => {
+      const { data } = await getProductsFromDb(1, 100, undefined, debouncedSearch || undefined);
+      if (!cancelled) {
+        setProducts(data);
+        setIsLoading(false);
+      }
+    };
+    void load();
+    return () => { cancelled = true; };
+  }, [debouncedSearch]);
 
   return (
     <div className="space-y-8 pb-10 animate-in fade-in duration-500">
@@ -83,7 +92,7 @@ export default function DashboardProductsPage() {
                     <p className="text-sm font-black uppercase tracking-widest text-muted-foreground/30">Memuat data produk...</p>
                   </td>
                 </tr>
-              ) : filteredProducts.length === 0 ? (
+              ) : products.length === 0 ? (
                 <tr>
                   <td colSpan={4} className="px-8 py-32 text-center">
                     <Package className="h-12 w-12 text-muted-foreground/20 mx-auto mb-4" />
@@ -91,7 +100,7 @@ export default function DashboardProductsPage() {
                   </td>
                 </tr>
               ) : (
-                filteredProducts.map((product) => {
+                products.map((product) => {
                   return (
                     <tr key={product.id} className="hover:bg-primary/[0.02] dark:hover:bg-primary/[0.05] transition-all duration-300 group">
                       <td className="px-8 py-6">

--- a/src/app/(dashboard)/dashboard/purchases/page.tsx
+++ b/src/app/(dashboard)/dashboard/purchases/page.tsx
@@ -459,46 +459,46 @@ export default function PurchasesPage() {
                             </div>
   
                             <div className="flex-1 max-w-lg">
-                              <Combobox 
-                                value={item.productId || ""} 
-                                onValueChange={(val) => updateItem(item.id, { productId: val ?? "" })}
-                              >
-                                <ComboboxTrigger className="h-14 font-black bg-white/50 dark:bg-gray-900/50 border-gray-200/50 dark:border-gray-800/50 rounded-2xl px-5 shadow-sm hover:border-primary/30 transition-all text-left group/trigger">
-                                  {item.productId ? (
-                                    <div className="flex flex-col items-start truncate">
-                                      <span className="text-[9px] text-primary/70 font-black uppercase tracking-[0.15em] leading-none mb-1">
-                                        {item.brandName || "Tanpa Brand"}
-                                      </span>
-                                      <span className="text-sm truncate w-full tracking-tight">
-                                        {item.productName}
-                                      </span>
-                                    </div>
-                                  ) : (
-                                    <span className="text-muted-foreground/60 text-sm font-medium italic">Cari barang by Nama/Brand...</span>
-                                  )}
-                                </ComboboxTrigger>
-                                <ComboboxContent align="start" className="w-(--anchor-width) min-w-[340px] p-2 rounded-2xl border-gray-200/50 dark:border-gray-800/50 shadow-2xl backdrop-blur-xl bg-white/90 dark:bg-gray-950/90">
-                                  <ComboboxInput placeholder="Tulis nama barang..." className="h-12 px-4 bg-gray-50 dark:bg-gray-900 rounded-xl mb-2 border-none focus:ring-1 focus:ring-primary/20" />
-                                  <ComboboxEmpty className="py-12 text-center">
-                                    <Package className="h-8 w-8 text-muted-foreground/20 mx-auto mb-3" />
-                                    <p className="text-[10px] font-black text-muted-foreground uppercase tracking-widest">SKU tidak ditemukan</p>
-                                  </ComboboxEmpty>
-                                  <ComboboxList className="space-y-1 max-h-72 overflow-y-auto pr-1">
-                                    {products.map(p => (
-                                      <ComboboxItem 
-                                        key={p.id} 
-                                        value={p.id} 
-                                        className="rounded-xl py-3 px-4 font-black cursor-pointer hover:bg-primary/5 transition-colors"
-                                      >
-                                        <div className="flex flex-col gap-1">
-                                          <span className="text-[10px] text-primary/70 font-black uppercase tracking-widest leading-none">{p.brand?.name || "Tanpa Brand"}</span>
-                                          <span className="text-sm tracking-tight">{p.name}</span>
-                                        </div>
-                                      </ComboboxItem>
-                                    ))}
-                                  </ComboboxList>
-                                </ComboboxContent>
-                              </Combobox>
+                            <Combobox 
+                              value={item.productId || ""} 
+                              onValueChange={(val) => updateItem(item.id, { productId: val ?? "" })}
+                            >
+                              <ComboboxTrigger className="h-14 font-black bg-white/50 dark:bg-gray-900/50 border-gray-200/50 dark:border-gray-800/50 rounded-2xl px-5 shadow-sm hover:border-primary/30 transition-all text-left group/trigger">
+                                {item.productId ? (
+                                  <div className="flex flex-col items-start truncate">
+                                    <span className="text-[9px] text-primary/70 font-black uppercase tracking-[0.15em] leading-none mb-1">
+                                      {item.brandName || "Tanpa Brand"}
+                                    </span>
+                                    <span className="text-sm truncate w-full tracking-tight">
+                                      {item.productName}
+                                    </span>
+                                  </div>
+                                ) : (
+                                  <span className="text-muted-foreground/60 text-sm font-medium italic">Cari barang by Nama/Brand...</span>
+                                )}
+                              </ComboboxTrigger>
+                              <ComboboxContent align="start" className="w-(--anchor-width) min-w-[340px] p-2 rounded-2xl border-gray-200/50 dark:border-gray-800/50 shadow-2xl backdrop-blur-xl bg-white/90 dark:bg-gray-950/90">
+                                <ComboboxInput placeholder="Tulis nama barang..." className="h-12 px-4 bg-gray-50 dark:bg-gray-900 rounded-xl mb-2 border-none focus:ring-1 focus:ring-primary/20" />
+                                <ComboboxEmpty className="py-12 text-center">
+                                  <Package className="h-8 w-8 text-muted-foreground/20 mx-auto mb-3" />
+                                  <p className="text-[10px] font-black text-muted-foreground uppercase tracking-widest">SKU tidak ditemukan</p>
+                                </ComboboxEmpty>
+                                <ComboboxList className="space-y-1 max-h-72 overflow-y-auto pr-1">
+                                  {products.map(p => (
+                                    <ComboboxItem 
+                                      key={p.id} 
+                                      value={p.id} 
+                                      className="rounded-xl py-3 px-4 font-black cursor-pointer hover:bg-primary/5 transition-colors"
+                                    >
+                                      <div className="flex flex-col gap-1">
+                                        <span className="text-[10px] text-primary/70 font-black uppercase tracking-widest leading-none">{p.brand?.name || "Tanpa Brand"}</span>
+                                        <span className="text-sm tracking-tight">{p.name}</span>
+                                      </div>
+                                    </ComboboxItem>
+                                  ))}
+                                </ComboboxList>
+                              </ComboboxContent>
+                            </Combobox>
                             </div>
   
                             <button type="button" onClick={() => removeItem(item.id)} className="h-12 w-12 flex items-center justify-center text-muted-foreground/20 hover:text-red-500 transition-all hover:bg-red-50 dark:hover:bg-red-900/20 rounded-2xl">

--- a/src/app/(dashboard)/dashboard/staff/page.tsx
+++ b/src/app/(dashboard)/dashboard/staff/page.tsx
@@ -37,10 +37,10 @@ export default function DashboardStaffPage() {
   const [selectedEmployee, setSelectedEmployee] = useState<Employee | null>(null);
   const [employeeToDelete, setEmployeeToDelete] = useState<Employee | null>(null);
 
-  const fetchEmployees = async () => {
+  const fetchEmployees = async (search?: string) => {
     try {
       setIsLoading(true);
-      const { data } = await api.employees.list();
+      const { data } = await api.employees.list(search);
       setEmployees(data);
     } catch {
       toast.error("Gagal memuat data pegawai");
@@ -68,11 +68,6 @@ export default function DashboardStaffPage() {
       toast.error(message);
     }
   };
-
-  const filteredEmployees = employees.filter(e => 
-    e.name.toLowerCase().includes(searchTerm.toLowerCase()) || 
-    e.email.toLowerCase().includes(searchTerm.toLowerCase())
-  );
 
   return (
     <div className="space-y-8 pb-10 animate-in fade-in slide-in-from-bottom-4 duration-500">
@@ -127,7 +122,7 @@ export default function DashboardStaffPage() {
                         <p className="text-sm font-black uppercase tracking-widest text-muted-foreground/30">Memuat data pegawai...</p>
                       </td>
                     </tr>
-                  ) : filteredEmployees.length === 0 ? (
+                  ) : employees.length === 0 ? (
                     <tr>
                       <td colSpan={4} className="px-8 py-32 text-center">
                         <Users className="h-12 w-12 text-muted-foreground/20 mx-auto mb-4" />
@@ -135,7 +130,7 @@ export default function DashboardStaffPage() {
                       </td>
                     </tr>
                   ) : (
-                    filteredEmployees.map((employee) => {
+                    employees.map((employee) => {
                       const isManager = employee.role === "MANAGER";
                       const isSelected = selectedEmployee?.id === employee.id;
                       return (

--- a/src/app/(dashboard)/dashboard/suppliers/page.tsx
+++ b/src/app/(dashboard)/dashboard/suppliers/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Truck } from "lucide-react";
 import { api, Supplier } from "@/lib/api";
@@ -9,27 +9,38 @@ import { SupplierList } from "@/components/dashboard/suppliers/SupplierList";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { toast } from "sonner";
 
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(handler);
+  }, [value, delay]);
+  return debouncedValue;
+}
+
 export default function DashboardSuppliersPage() {
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedSupplier, setSelectedSupplier] = useState<Supplier | null>(null);
   const [supplierToDelete, setSupplierToDelete] = useState<Supplier | null>(null);
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebounce(search, 300);
 
-  const fetchSuppliers = async () => {
+  const fetchSuppliers = useCallback(async (searchTerm?: string) => {
     try {
       setIsLoading(true);
-      const { data } = await api.suppliers.list();
+      const { data } = await api.suppliers.list(searchTerm);
       setSuppliers(data);
     } catch {
       toast.error("Gagal memuat data supplier");
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    fetchSuppliers();
-  }, []);
+    fetchSuppliers(debouncedSearch || undefined);
+  }, [debouncedSearch, fetchSuppliers]);
 
   const handleDelete = async () => {
     if (!supplierToDelete) return;
@@ -37,7 +48,7 @@ export default function DashboardSuppliersPage() {
       await api.suppliers.delete(supplierToDelete.id);
       toast.success("Supplier berhasil dihapus");
       setSupplierToDelete(null);
-      fetchSuppliers();
+      fetchSuppliers(debouncedSearch || undefined);
       if (selectedSupplier?.id === supplierToDelete.id) {
         setSelectedSupplier(null);
       }
@@ -72,6 +83,8 @@ export default function DashboardSuppliersPage() {
           <SupplierList
             suppliers={suppliers}
             isLoading={isLoading}
+            search={search}
+            onSearchChange={setSearch}
             onEdit={(supplier) => {
               setSelectedSupplier(supplier);
               const el = document.getElementById("supplier-form-section");
@@ -86,7 +99,7 @@ export default function DashboardSuppliersPage() {
             <SupplierForm
               supplier={selectedSupplier}
               onSuccess={() => {
-                fetchSuppliers();
+                fetchSuppliers(debouncedSearch || undefined);
                 setSelectedSupplier(null);
               }}
               onCancel={() => setSelectedSupplier(null)}

--- a/src/components/dashboard/consignment/ConsignmentDataList.tsx
+++ b/src/components/dashboard/consignment/ConsignmentDataList.tsx
@@ -4,12 +4,10 @@ import {
   Handshake, 
   Search, 
   MoreVertical,
-  Package,
   Calendar,
   Calculator,
   Eye,
   Trash2,
-  Clock,
   ArrowRight
 } from "lucide-react";
 import { 
@@ -38,6 +36,8 @@ import { useState, useMemo } from "react";
 interface ConsignmentDataListProps {
   consignments: Consignment[];
   isLoading: boolean;
+  search: string;
+  onSearchChange: (value: string) => void;
   onSettle: (consignment: Consignment) => void;
   onDetail: (consignment: Consignment) => void;
 }
@@ -45,21 +45,19 @@ interface ConsignmentDataListProps {
 export function ConsignmentDataList({ 
   consignments, 
   isLoading, 
+  search,
+  onSearchChange,
   onSettle, 
   onDetail 
 }: ConsignmentDataListProps) {
-  const [search, setSearch] = useState("");
   const [filter, setFilter] = useState("ALL");
 
   const filteredConsignments = useMemo(() => {
     return consignments.filter(c => {
-      const matchesSearch = 
-        c.supplier?.name.toLowerCase().includes(search.toLowerCase()) || 
-        c.id.toLowerCase().includes(search.toLowerCase());
       const matchesFilter = filter === "ALL" || c.status === filter;
-      return matchesSearch && matchesFilter;
+      return matchesFilter;
     });
-  }, [consignments, search, filter]);
+  }, [consignments, filter]);
 
   return (
     <div id="history" className="space-y-6">
@@ -78,7 +76,7 @@ export function ConsignmentDataList({
               placeholder="Cari Entitas atau Kode Protokol..." 
               className="h-16 pl-14 pr-8 rounded-[2rem] bg-white/50 dark:bg-gray-950/50 border-gray-200/50 dark:border-white/5 shadow-sm focus:shadow-emerald-500/5 focus:ring-primary/5 transition-all font-black text-[11px] uppercase tracking-widest placeholder:text-muted-foreground/30"
               value={search}
-              onChange={(e) => setSearch(e.target.value)}
+              onChange={(e) => onSearchChange(e.target.value)}
             />
           </div>
           <div className="flex h-16 bg-gray-100/50 dark:bg-white/[0.03] p-2 rounded-[2rem] border border-gray-200/50 dark:border-white/5 w-full md:w-auto backdrop-blur-xl gap-2">

--- a/src/components/dashboard/consignment/ConsignmentDetailView.tsx
+++ b/src/components/dashboard/consignment/ConsignmentDetailView.tsx
@@ -8,8 +8,6 @@ import {
   Tag,
   ArrowRight,
   ShieldCheck,
-  Zap,
-  RefreshCw,
   Box,
   Truck,
   Calculator
@@ -115,7 +113,7 @@ export function ConsignmentDetailView({
                     </TableRow>
                   </TableHeader>
                   <TableBody className="divide-y divide-gray-100 dark:divide-white/5">
-                    {consignment.items?.map((item, idx) => (
+                    {consignment.items?.map((item) => (
                       <TableRow key={item.id} className="group/row hover:bg-white/80 dark:hover:bg-black/40 transition-all duration-500 border-none">
                         <TableCell className="px-10 py-8 text-[11px] font-black text-muted-foreground/30 font-mono uppercase tracking-widest italic">{item.id.split('-')[0]}</TableCell>
                         <TableCell className="px-10 py-8">

--- a/src/components/dashboard/consignment/SettlementDialog.tsx
+++ b/src/components/dashboard/consignment/SettlementDialog.tsx
@@ -10,19 +10,12 @@ import {
   DialogFooter
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { 
   Calculator,
-  Handshake,
   Check,
-  Package,
-  TrendingUp,
   AlertTriangle,
-  ArrowRight
 } from "lucide-react";
-import { cn } from "@/lib/utils";
 
 import { Consignment } from "@/types/financial";
 

--- a/src/components/dashboard/suppliers/SupplierList.tsx
+++ b/src/components/dashboard/suppliers/SupplierList.tsx
@@ -19,29 +19,17 @@ import {
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
 import { Supplier } from "@/lib/api";
-import { useState, useMemo } from "react";
 
 interface SupplierListProps {
   suppliers: Supplier[];
   isLoading: boolean;
+  search: string;
+  onSearchChange: (value: string) => void;
   onEdit: (supplier: Supplier) => void;
   onDelete: (supplier: Supplier) => void;
 }
 
-export function SupplierList({ suppliers, isLoading, onEdit, onDelete }: SupplierListProps) {
-  const [search, setSearch] = useState("");
-
-  const filteredSuppliers = useMemo(() => {
-    return suppliers.filter((s) => {
-      const term = search.toLowerCase();
-      return (
-        s.name.toLowerCase().includes(term) ||
-        (s.contactName?.toLowerCase().includes(term) ?? false) ||
-        (s.email?.toLowerCase().includes(term) ?? false)
-      );
-    });
-  }, [suppliers, search]);
-
+export function SupplierList({ suppliers, isLoading, search, onSearchChange, onEdit, onDelete }: SupplierListProps) {
   return (
     <div className="space-y-6">
       <div className="relative group">
@@ -50,7 +38,7 @@ export function SupplierList({ suppliers, isLoading, onEdit, onDelete }: Supplie
           placeholder="Cari nama, kontak, atau email..."
           className="pl-12 h-14 bg-white/50 dark:bg-gray-950/50 border-gray-200/50 dark:border-gray-800/50 rounded-2xl shadow-sm focus:shadow-md focus:ring-primary/20 transition-all text-base font-medium"
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(e) => onSearchChange(e.target.value)}
         />
       </div>
 
@@ -73,7 +61,7 @@ export function SupplierList({ suppliers, isLoading, onEdit, onDelete }: Supplie
                     <p className="text-sm font-black uppercase tracking-widest text-muted-foreground/30">Memuat data supplier...</p>
                   </TableCell>
                 </TableRow>
-              ) : filteredSuppliers.length === 0 ? (
+              ) : suppliers.length === 0 ? (
                 <TableRow className="hover:bg-transparent">
                   <TableCell colSpan={5} className="px-8 py-32 text-center">
                     <Truck className="h-12 w-12 text-muted-foreground/20 mx-auto mb-4" />
@@ -81,7 +69,7 @@ export function SupplierList({ suppliers, isLoading, onEdit, onDelete }: Supplie
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredSuppliers.map((supplier) => (
+                suppliers.map((supplier) => (
                   <TableRow key={supplier.id} className="hover:bg-primary/[0.02] dark:hover:bg-primary/[0.05] transition-all duration-300 group">
                     <TableCell className="px-8 py-6">
                       <div className="flex items-center gap-4">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -206,7 +206,7 @@ export const api = {
   },
 
   employees: {
-    list: () => api.get<Employee[]>('/employees'),
+    list: (search?: string) => api.get<Employee[]>(`/employees${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     create: (data: CreateEmployeeDto) => api.post<Employee>('/employees', data),
     update: (id: string, data: UpdateEmployeeDto) => api.patch<Employee>(`/employees/${id}`, data),
     delete: (id: string) => api.delete<{ message: string; id: string }>(`/employees/${id}`),
@@ -214,8 +214,16 @@ export const api = {
 
  
   products: {
+    list: (page = 1, limit = 10, taste?: string, search?: string) => {
+      const qs = new URLSearchParams();
+      qs.append('page', String(page));
+      qs.append('limit', String(limit));
+      if (taste) qs.append('taste', taste);
+      if (search) qs.append('search', search);
+      return api.get<unknown>(`/products?${qs.toString()}`);
+    },
     getPricing: (id: string) => api.get<PricingRule[]>(`/products/${id}/pricing`),
-    getBrands: () => api.get<Brand[]>('/products/brands'),
+    getBrands: (search?: string) => api.get<Brand[]>(`/products/brands${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     createBrand: (name: string) => api.post<Brand>('/products/brands', { name }),
     create: (data: Record<string, unknown>) => api.post<Record<string, unknown>>('/products', data),
   },
@@ -230,19 +238,20 @@ export const api = {
   },
 
   stock: {
-    movements: (params?: { productVariantId?: string; productId?: string; type?: string; limit?: number }) => {
+    movements: (params?: { productVariantId?: string; productId?: string; type?: string; limit?: number; search?: string }) => {
       const qs = new URLSearchParams();
       if (params?.productVariantId) qs.append('productVariantId', params.productVariantId);
       if (params?.productId) qs.append('productId', params.productId);
       if (params?.type) qs.append('type', params.type);
       if (params?.limit) qs.append('limit', params.limit.toString());
+      if (params?.search) qs.append('search', params.search);
       return api.get<StockMovement[]>(`/stock/movements?${qs.toString()}`);
     },
     adjust: (data: AdjustStockDto) => api.post<StockMovement>('/stock/adjust', data),
   },
 
   purchases: {
-    list: () => api.get<Purchase[]>('/purchases'),
+    list: (search?: string) => api.get<Purchase[]>(`/purchases${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     get: (id: string) => api.get<Purchase>(`/purchases/${id}`),
     create: (data: CreatePurchaseDto) => api.post<{ id: string }>('/purchases', data),
     update: (id: string, data: Partial<CreatePurchaseDto>) => api.put<Purchase>(`/purchases/${id}`, data),
@@ -270,7 +279,7 @@ export const api = {
   },
 
   suppliers: {
-    list: () => api.get<Supplier[]>('/suppliers'),
+    list: (search?: string) => api.get<Supplier[]>(`/suppliers${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     create: (data: CreateSupplierDto) => api.post<Supplier>('/suppliers', data),
     update: (id: string, data: UpdateSupplierDto) => api.patch<Supplier>(`/suppliers/${id}`, data),
     delete: (id: string) => api.delete<{ message: string; id: string }>(`/suppliers/${id}`),
@@ -282,20 +291,25 @@ export const api = {
   },
 
   repacks: {
-    list: (productId?: string) =>
-      api.get<Repack[]>(`/repacks${productId ? `?productId=${productId}` : ''}`),
+    list: (productId?: string, search?: string) => {
+      const qs = new URLSearchParams();
+      if (productId) qs.append('productId', productId);
+      if (search) qs.append('search', search);
+      const query = qs.toString();
+      return api.get<Repack[]>(`/repacks${query ? `?${query}` : ''}`);
+    },
     get: (id: string) => api.get<Repack>(`/repacks/${id}`),
     create: (data: CreateRepackDto) => api.post<{ id: string; message: string }>('/repacks', data),
   },
 
   orders: {
-    list: () => api.get<Order[]>('/orders'),
+    list: (search?: string) => api.get<Order[]>(`/orders${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     get: (id: string) => api.get<Order>(`/orders/${id}`),
     create: (data: CreateOrderDto) => api.post<{ data: Order; message: string }>('/orders', data),
   },
 
   consignment: {
-    list: () => api.get<Consignment[]>('/consignment'),
+    list: (search?: string) => api.get<Consignment[]>(`/consignment${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     get: (id: string) => api.get<Consignment>(`/consignment/${id}`),
     create: (data: CreateConsignmentDto) => api.post<Consignment>('/consignment', data),
     settle: (data: SettleConsignmentDto) => 

--- a/src/lib/products-db.ts
+++ b/src/lib/products-db.ts
@@ -99,10 +99,11 @@ export async function getProductById(id: string): Promise<Product | null> {
   }
 }
 
-export async function getProductsFromDb(page: number = 1, limit: number = 12, taste?: string): Promise<PaginatedProducts> {
+export async function getProductsFromDb(page: number = 1, limit: number = 12, taste?: string, search?: string): Promise<PaginatedProducts> {
   try {
     let url = `/products?page=${page}&limit=${limit}`;
     if (taste) url += `&taste=${taste}`;
+    if (search) url += `&search=${encodeURIComponent(search)}`;
     
     const response = await api.get<BackendProduct[]>(url);
     


### PR DESCRIPTION
## Summary
- Convert all client-side search bars to server-side API calls with 300ms debounce
- Update API client (`src/lib/api.ts`) to pass `search` param on all list endpoints
- Update `products-db.ts` to support `search` param
- Pre-existing lint fixes in ConsignmentDetailView and SettlementDialog

## Pages Updated
| Page | Search Target | Implementation |
|------|--------------|----------------|
| Dashboard Products | Product name | Server-side via `GET /products?search=` |
| Dashboard POS | Product name | Server-side via `GET /products?search=` |
| Dashboard Staff | Employee name/email | Server-side via `GET /employees?search=` |
| Dashboard Suppliers | Supplier name | Server-side via `GET /suppliers?search=` |
| Dashboard Consignment | Supplier name | Server-side via `GET /consignment?search=` |

## Comboboxes (retain client-side filtering)
- Purchases page supplier/product comboboxes
- Repacks page product combobox
- Stock adjustment product combobox

## Dependencies
- Requires: [mamuncloud/pns-server#9](https://github.com/mamuncloud/pns-server/pull/9)

Closes #19