### PR TITLE
feat(products): add variant creation with API integration

### DIFF
--- a/src/app/(dashboard)/dashboard/products/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/products/[id]/page.tsx
@@ -2,24 +2,11 @@
 
 import { useEffect, useState, use } from "react";
 import { getProductById } from "@/lib/products-db";
-import { Product, EnumTaste } from "@/types/product";
+import { Product, ProductImage, EnumTaste } from "@/types/product";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { 
-  ArrowLeft, 
-  TrendingUp, 
-  Lightbulb,
-  Image as ImageIcon,
-  Package,
-  Layers,
-  Tag,
-  Plus,
-  Scissors
-} from "lucide-react";
-import Link from "next/link";
-import { cn, getProductImageUrl, formatCurrency } from "@/lib/utils";
-import Image from "next/image";
+import { VariantCreateDialog } from "@/components/dashboard/products/VariantCreateDialog";
 import {
   Carousel,
   CarouselContent,
@@ -28,13 +15,152 @@ import {
   CarouselPrevious,
 } from "@/components/ui/carousel";
 import { Breadcrumbs } from "@/components/dashboard/Breadcrumbs";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { StockMovementList } from "@/components/dashboard/stock/StockMovementList";
+import {
+  ArrowLeft,
+  Package,
+  Tag,
+  Scissors,
+  Image as ImageIcon,
+  TrendingUp,
+  Lightbulb,
+  MapPin,
+  FileText,
+  History,
+} from "lucide-react";
+import Link from "next/link";
+import Image from "next/image";
+import { cn, getProductImageUrl, formatCurrency } from "@/lib/utils";
+
+function ProductImageGallery({ images, productName }: { images: ProductImage[]; productName: string }) {
+  if (images.length > 1) {
+    return (
+      <Carousel className="w-full">
+        <CarouselContent>
+          {images.map((image, index) => (
+            <CarouselItem key={image.id || index}>
+              <div className="relative aspect-square overflow-hidden rounded-2xl bg-gray-50 dark:bg-gray-900">
+                <Image
+                  src={image.url}
+                  alt={`${productName} - image ${index + 1}`}
+                  fill
+                  className="object-cover"
+                  sizes="(max-width: 768px) 100vw, 33vw"
+                />
+              </div>
+            </CarouselItem>
+          ))}
+        </CarouselContent>
+        <CarouselPrevious className="left-4" />
+        <CarouselNext className="right-4" />
+      </Carousel>
+    );
+  }
+
+  return (
+    <div className="relative aspect-square overflow-hidden rounded-2xl bg-gray-50 dark:bg-gray-900">
+      <Image
+        src={images[0].url}
+        alt={productName}
+        fill
+        className="object-cover"
+        sizes="(max-width: 768px) 100vw, 33vw"
+      />
+      {!images[0].url.includes("placeholder") && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-muted-foreground/50 bg-gray-100/50 dark:bg-gray-800/50">
+          <ImageIcon className="h-10 w-10 mb-2" />
+          <span className="text-xs">No product image</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProductInsightsCard({ product }: { product: Product }) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-lg bg-amber-500/10 flex items-center justify-center">
+            <Lightbulb className="h-4 w-4 text-amber-500" />
+          </div>
+          <CardTitle className="text-base">Product Insights</CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {product.latestSupplier && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+              <MapPin className="h-3.5 w-3.5" />
+              Latest Supplier
+            </p>
+            <div className="p-3 rounded-lg bg-muted/50">
+              <p className="text-sm">{product.latestSupplier.name}</p>
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+            <FileText className="h-3.5 w-3.5" />
+            Description
+          </p>
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            {product.description || "No description available for this product."}
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+            <Tag className="h-3.5 w-3.5" />
+            Taste Profile
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {product.taste.map((t: EnumTaste, idx: number) => (
+              <Badge key={idx} variant="secondary" className="text-xs">
+                {t}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ProductStockCard({ product }: { product: Product }) {
+  const totalStock = product.variants.reduce((sum, v) => sum + (v.stock || 0), 0);
+
+  return (
+    <Card className="bg-gradient-to-br from-indigo-500 to-indigo-600 text-white border-none">
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <p className="text-xs text-indigo-100">Total Stock</p>
+            <p className="text-3xl">{totalStock.toLocaleString("id-ID")} pcs</p>
+          </div>
+          <TrendingUp className="h-10 w-10 text-indigo-200/50" />
+        </div>
+        <div className="mt-4 pt-4 border-t border-indigo-400/30">
+          <div className="flex items-center justify-between text-xs text-indigo-100">
+            <span>Variants</span>
+            <span className="">{product.variants.length}</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 export default function ProductDetailPage({ params }: { params: Promise<{ id: string }> }) {
   const resolvedParams = use(params);
   const [product, setProduct] = useState<Product | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  const refreshProduct = async () => {
+    const p = await getProductById(resolvedParams.id);
+    setProduct(p);
+  };
 
   useEffect(() => {
     async function fetchProduct() {
@@ -47,184 +173,140 @@ export default function ProductDetailPage({ params }: { params: Promise<{ id: st
   }, [resolvedParams.id]);
 
   if (isLoading) {
-    return <div className="p-10 text-center font-bold animate-pulse text-muted-foreground uppercase tracking-widest text-sm">Memuat detail produk...</div>;
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="text-center space-y-3">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-primary border-t-transparent mx-auto" />
+          <p className="text-sm text-muted-foreground">Loading product details...</p>
+        </div>
+      </div>
+    );
   }
 
   if (!product) {
     return (
-      <div className="p-10 text-center space-y-4">
-        <p className="text-xl font-black text-foreground uppercase">Produk tidak ditemukan</p>
+      <div className="flex flex-col items-center justify-center py-20 space-y-4">
+        <Package className="h-12 w-12 text-muted-foreground/30" />
+        <p className="text-lg">Product not found</p>
         <Link href="/dashboard/products">
-          <Button variant="outline" className="font-bold uppercase tracking-wider">Kembali ke Daftar</Button>
+          <Button variant="outline">Back to Products</Button>
         </Link>
       </div>
     );
   }
 
-  const images = product.images && product.images.length > 0 
-    ? product.images 
-    : [{ url: product.imageUrl || getProductImageUrl(null), id: 'default', isPrimary: true }];
+  const images = product.images && product.images.length > 0
+    ? product.images
+    : [{ url: product.imageUrl || getProductImageUrl(null), id: "default", isPrimary: true } as ProductImage];
 
   return (
-    <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-500 pb-10">
-      <div className="flex flex-col gap-6">
-        <Breadcrumbs 
-          items={[
-            { label: "Products", href: "/dashboard/products" },
-            { label: product.name }
-          ]} 
-        />
-        
-        <div className="flex items-center gap-6">
+    <div className="space-y-6 pb-10">
+      <Breadcrumbs
+        items={[
+          { label: "Products", href: "/dashboard/products" },
+          { label: product.name }
+        ]}
+      />
+
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-4">
           <Link href="/dashboard/products">
-            <Button variant="ghost" size="icon" className="rounded-full h-12 w-12 hover:bg-gray-100 dark:hover:bg-gray-800 transition-all shadow-sm hover:shadow-md border border-gray-100 dark:border-gray-800">
-              <ArrowLeft className="h-6 w-6" />
+            <Button variant="ghost" size="icon" className="mt-1">
+              <ArrowLeft className="h-5 w-5" />
             </Button>
           </Link>
-          <div className="flex flex-col">
-            <div className="flex items-center gap-3 mb-2">
-               <Badge variant="outline" className="bg-primary/10 text-primary border-primary/20 font-black text-[10px] uppercase tracking-[0.3em] px-4 py-1.5 rounded-full shadow-sm">
-                 {product.brand?.name || "No Brand"}
-               </Badge>
-               <span className="text-[10px] font-black text-muted-foreground/40 uppercase tracking-[0.25em]">
-                 ID: {product.id.split('-')[0]}
-               </span>
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className="text-xs">
+                {product.brand?.name || "No Brand"}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                {product.id.split("-")[0]}
+              </span>
             </div>
-            <h2 className="text-6xl font-black text-foreground tracking-tighter uppercase italic bg-gradient-to-br from-foreground to-foreground/40 bg-clip-text text-transparent leading-[0.85]">
-              {product.name}
-            </h2>
-            <div className="flex items-center gap-3 mt-4">
-               <div className="flex flex-wrap gap-2">
-                 {product.taste.map((t: EnumTaste, i: number) => (
-                   <span key={i} className="text-[10px] font-black text-primary/70 uppercase tracking-widest bg-primary/10 px-3 py-1 rounded-lg border border-primary/20 shadow-sm animate-in zoom-in-95 duration-500" style={{ animationDelay: `${i * 100}ms` }}>#{t}</span>
-                 ))}
-               </div>
+            <h1 className="text-3xl tracking-tight">{product.name}</h1>
+            <div className="flex flex-wrap gap-2">
+              {product.taste.map((t: EnumTaste, i: number) => (
+                <Badge key={i} variant="secondary" className="text-xs">
+                  #{t}
+                </Badge>
+              ))}
             </div>
           </div>
-          {/* Action Buttons */}
-          <div className="ml-auto flex items-center gap-3">
-            <Link href={`/dashboard/repacks?productId=${product.id}`}>
-              <Button
-                id="btn-pecah-produk"
-                variant="outline"
-                className="h-14 px-8 rounded-2xl font-black text-[11px] uppercase tracking-widest border-primary/20 text-primary hover:bg-primary/5 hover:border-primary/40 transition-all gap-3 shadow-sm bg-white/50 dark:bg-gray-950/50 backdrop-blur-sm group"
-              >
-                <Scissors className="h-5 w-5 transition-transform group-hover:rotate-12 duration-300" />
-                Pecah Produk
-              </Button>
-            </Link>
-          </div>
+        </div>
+
+        <div className="flex items-center gap-2 sm:ml-auto">
+          <Link href={`/dashboard/repacks?productId=${product.id}`}>
+            <Button variant="outline" className="gap-2">
+              <Scissors className="h-4 w-4" />
+              Pecah Produk
+            </Button>
+          </Link>
         </div>
       </div>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-        {/* Main Info */}
+      {/* Main Content Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left Column - Variants & Stock History */}
         <div className="lg:col-span-2 space-y-8">
-
-          <Tabs defaultValue="variants" className="w-full space-y-6">
-            <TabsList className="h-14 bg-gray-100/50 dark:bg-gray-900/50 p-1.5 rounded-2xl w-full justify-start overflow-x-auto space-x-2">
-              <TabsTrigger value="variants" className="rounded-xl px-8 h-full text-[11px] font-black uppercase tracking-widest data-[state=active]:bg-white dark:data-[state=active]:bg-gray-950 data-[state=active]:text-primary data-[state=active]:shadow-xl transition-all">
-                Daftar Varian
-              </TabsTrigger>
-              <TabsTrigger value="ledger" className="rounded-xl px-8 h-full text-[11px] font-black uppercase tracking-widest data-[state=active]:bg-white dark:data-[state=active]:bg-gray-950 data-[state=active]:text-primary data-[state=active]:shadow-xl transition-all">
-                Riwayat Stok
-              </TabsTrigger>
-            </TabsList>
-
-            <TabsContent value="variants" className="m-0 border-none outline-none">
-              {/* Variants Table */}
-              <Card className="border-gray-200/50 dark:border-gray-800/50 shadow-2xl overflow-hidden bg-white/80 dark:bg-gray-950/80 backdrop-blur-2xl rounded-[2.5rem] border-none shadow-gray-200/50 dark:shadow-none">
-            <CardHeader className="bg-gradient-to-r from-gray-50/50 to-transparent dark:from-gray-900/50 dark:to-transparent border-b border-gray-100/50 dark:border-gray-800/50 p-8">
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-                <div className="space-y-1">
-                  <CardTitle className="text-3xl font-black uppercase tracking-tighter italic bg-gradient-to-br from-foreground to-foreground/50 bg-clip-text text-transparent">Varian Produk</CardTitle>
-                  <CardDescription className="text-[10px] font-black uppercase tracking-[0.2em] text-muted-foreground/40">Rincian stok dan harga jual secara realtime.</CardDescription>
-                </div>
-                <Button className="h-14 px-8 rounded-2xl font-black text-[12px] uppercase tracking-widest bg-gradient-to-r from-red-500 to-rose-600 hover:from-red-600 hover:to-rose-700 text-white shadow-xl shadow-red-500/20 hover:shadow-red-500/40 transition-all hover:scale-[1.05] active:scale-[0.95] border-none group">
-                  <Plus className="h-5 w-5 mr-2 stroke-[4] group-hover:rotate-90 transition-transform duration-300" />
-                  Tambah Varian
-                </Button>
+          {/* Variants Section */}
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-4">
+              <div>
+                <CardTitle>Product Variants</CardTitle>
+                <CardDescription>
+                  Stock levels and pricing for each variant
+                </CardDescription>
               </div>
+              <VariantCreateDialog productId={product.id} onSuccess={refreshProduct} />
             </CardHeader>
-            <CardContent className="p-0">
-              <div className="overflow-x-auto min-h-[300px]">
-                <table className="w-full text-left border-collapse">
+            <CardContent>
+              <div className="overflow-x-auto">
+                <table className="w-full">
                   <thead>
-                    <tr className="bg-gray-50/30 dark:bg-gray-900/10 border-b border-gray-100/50 dark:border-gray-800/50">
-                      <th className="px-8 py-5 text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/60">
-                        <div className="flex items-center gap-2">
-                          <Package className="h-3 w-3 text-primary/50" />
-                          Packaging
-                        </div>
+                    <tr className="border-b">
+                      <th className="text-left py-3 px-4 text-xs text-muted-foreground">
+                        Packaging
                       </th>
-                      <th className="px-8 py-5 text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/60">
-                        <div className="flex items-center gap-2">
-                          <Layers className="h-3 w-3 text-primary/50" />
-                          Qty Stok
-                        </div>
+                      <th className="text-left py-3 px-4 text-xs text-muted-foreground">
+                        Stock
                       </th>
-                      <th className="px-8 py-5 text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/60">
-                        <div className="flex items-center gap-2">
-                          <Tag className="h-3 w-3 text-primary/50" />
-                          Harga Jual
-                        </div>
+                      <th className="text-left py-3 px-4 text-xs text-muted-foreground">
+                        Selling Price
                       </th>
-                      <th className="px-8 py-5 text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/60">
-                        <div className="flex items-center gap-2">
-                          <Package className="h-3 w-3 text-primary/50" />
-                          Ukuran
-                        </div>
+                      <th className="text-left py-3 px-4 text-xs text-muted-foreground">
+                        Size
                       </th>
-                      <th className="px-8 py-5"></th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-gray-50/50 dark:divide-gray-900/50">
+                  <tbody>
                     {product.variants.map((v, idx: number) => (
-                      <tr key={idx} className="hover:bg-primary/[0.02] dark:hover:bg-primary/[0.05] transition-all duration-500 group">
-                        <td className="px-8 py-6">
-                          <div className="flex flex-col gap-1">
-                            <span className="text-base font-black text-foreground uppercase tracking-tight group-hover:text-primary transition-colors">{v.package}</span>
-                            <span className="text-[9px] font-black text-muted-foreground/30 uppercase tracking-[0.15em] flex items-center gap-1.5">
-                              <span className="h-1 w-1 rounded-full bg-primary/20" />
-                              SKU: PN-{v.package.toUpperCase()}
-                            </span>
+                      <tr key={idx} className="border-b last:border-0 hover:bg-muted/50">
+                        <td className="py-3 px-4">
+                          <div className="flex items-center gap-2">
+                            <Package className="h-4 w-4 text-muted-foreground" />
+                            <span className="text-sm">{v.package}</span>
                           </div>
                         </td>
-                        <td className="px-8 py-6">
-                          <div className="inline-flex items-center gap-3 px-4 py-2 rounded-2xl bg-gray-50 dark:bg-gray-900/50 border border-gray-100/50 dark:border-gray-800/50 transition-all group-hover:border-primary/20">
-                             <div className={cn(
-                               "h-2.5 w-2.5 rounded-full",
-                               (v.stock || 0) > 10 ? "bg-emerald-500 shadow-[0_0_12px_rgba(16,185,129,0.4)]" : (v.stock || 0) > 0 ? "bg-amber-500 shadow-[0_0_12px_rgba(245,158,11,0.4)]" : "bg-red-500 shadow-[0_0_12px_rgba(239,68,68,0.4)]"
-                             )} />
-                             <div className="flex flex-col">
-                               <span className={cn(
-                                 "text-xl font-black tracking-tighter leading-none",
-                                 (v.stock || 0) <= 5 ? "text-red-500" : "text-foreground"
-                               )}>{v.stock || 0}</span>
-                               <span className="text-[8px] font-black text-muted-foreground uppercase tracking-widest opacity-40">Qty Unit</span>
-                             </div>
+                        <td className="py-3 px-4">
+                          <div className="flex items-center gap-2">
+                            <div className={cn(
+                              "h-2 w-2 rounded-full",
+                              (v.stock || 0) > 10 ? "bg-emerald-500" : (v.stock || 0) > 0 ? "bg-amber-500" : "bg-red-500"
+                            )} />
+                            <span className="text-sm">{v.stock || 0}</span>
                           </div>
                         </td>
-                        <td className="px-8 py-6">
-                          <div className="flex flex-col gap-1">
-                            <span className="text-xl font-black text-foreground tracking-tighter bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">{formatCurrency(v.price)}</span>
-                            <span className="text-[9px] font-black text-muted-foreground/40 uppercase tracking-widest pl-0.5">Price Per {v.package}</span>
-                          </div>
+                        <td className="py-3 px-4">
+                          <span className="text-sm">{formatCurrency(v.price)}</span>
                         </td>
-                        <td className="px-8 py-6">
+                        <td className="py-3 px-4">
                           {v.sizeInGram ? (
-                            <div className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-xl bg-amber-500/[0.08] dark:bg-amber-500/10 border border-amber-500/20">
-                              <span className="text-base font-black text-amber-600 dark:text-amber-400 tracking-tighter">{v.sizeInGram}</span>
-                              <span className="text-[9px] font-black text-amber-600/60 dark:text-amber-500/70 uppercase tracking-widest">gram</span>
-                            </div>
+                            <span className="text-sm">{v.sizeInGram}g</span>
                           ) : (
-                            <span className="text-[10px] text-muted-foreground/20 font-bold uppercase tracking-widest">—</span>
+                            <span className="text-xs text-muted-foreground">—</span>
                           )}
-                        </td>
-                        <td className="px-8 py-6 text-right">
-                          <Button variant="outline" size="sm" className="h-9 px-5 rounded-xl font-black text-[10px] uppercase tracking-widest border-gray-100 dark:border-gray-800 text-muted-foreground/60 hover:text-primary hover:border-primary/30 hover:bg-primary/5 transition-all opacity-0 group-hover:opacity-100 translate-x-4 group-hover:translate-x-0">
-                            Edit
-                          </Button>
                         </td>
                       </tr>
                     ))}
@@ -233,128 +315,22 @@ export default function ProductDetailPage({ params }: { params: Promise<{ id: st
               </div>
             </CardContent>
           </Card>
-          </TabsContent>
 
-          <TabsContent value="ledger" className="m-0 border-none outline-none">
-            <StockMovementList productId={product.id} className="rounded-[2.5rem] border-none shadow-2xl bg-white/80 dark:bg-gray-950/80 backdrop-blur-2xl" />
-          </TabsContent>
-        </Tabs>
+          {/* Stock History Section */}
+          <div className="space-y-4">
+            <div className="flex items-center gap-2">
+              <History className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-lg font-semibold">Stock History</h2>
+            </div>
+            <StockMovementList productId={product.id} />
+          </div>
         </div>
 
-        {/* Sidebar Info */}
-        <div className="space-y-8">
-          {/* Image Display */}
-          <Card className="border-gray-200 dark:border-gray-800 shadow-2xl overflow-hidden bg-white dark:bg-gray-950 rounded-3xl group">
-            <CardContent className="p-0">
-              {images.length > 1 ? (
-                <Carousel className="w-full">
-                  <CarouselContent>
-                    {images.map((image, index) => (
-                      <CarouselItem key={image.id || index}>
-                        <div className="relative aspect-square overflow-hidden bg-gray-50 dark:bg-gray-900">
-                          <Image
-                            src={image.url}
-                            alt={`${product.name} - image ${index + 1}`}
-                            fill
-                            className="object-cover transition-transform duration-1000 group-hover:scale-110"
-                            sizes="(max-width: 768px) 100vw, 33vw"
-                          />
-                        </div>
-                      </CarouselItem>
-                    ))}
-                  </CarouselContent>
-                  <div className="absolute inset-0 flex items-center justify-between p-4 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
-                    <CarouselPrevious className="relative left-0 translate-y-0 h-10 w-10 bg-white/90 dark:bg-black/70 backdrop-blur-xl border-none shadow-2xl hover:bg-white dark:hover:bg-black cursor-pointer" />
-                    <CarouselNext className="relative right-0 translate-y-0 h-10 w-10 bg-white/90 dark:bg-black/70 backdrop-blur-xl border-none shadow-2xl hover:bg-white dark:hover:bg-black cursor-pointer" />
-                  </div>
-                </Carousel>
-              ) : (
-                <div className="relative aspect-square overflow-hidden bg-gray-50 dark:bg-gray-900">
-                  <Image
-                    src={images[0].url}
-                    alt={product.name}
-                    fill
-                    className="object-cover transition-transform duration-1000 group-hover:scale-110"
-                    sizes="(max-width: 768px) 100vw, 33vw"
-                  />
-                  {!product.imageUrl && (
-                     <div className="absolute inset-0 flex flex-col items-center justify-center text-muted-foreground/30 bg-black/5">
-                        <ImageIcon className="h-12 w-12 mb-2 stroke-[1.5]" />
-                        <span className="text-[10px] font-black uppercase tracking-widest">No primary image</span>
-                     </div>
-                  )}
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Insight Panel */}
-          <Card className="border-gray-200/50 dark:border-gray-800/50 shadow-2xl overflow-hidden bg-white/70 dark:bg-gray-950/70 backdrop-blur-2xl rounded-[2.5rem] border-none">
-            <CardHeader className="border-b border-gray-100/50 dark:border-gray-800/50 p-8 bg-gray-50/20 dark:bg-gray-900/10">
-              <CardTitle className="text-[11px] font-black flex items-center gap-3 text-foreground uppercase tracking-[0.25em]">
-                <div className="h-8 w-8 rounded-xl bg-amber-500/10 flex items-center justify-center">
-                  <Lightbulb className="h-4 w-4 text-amber-500 animate-pulse" />
-                </div>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="p-8 space-y-10 flex-grow">
-              <div className="space-y-4">
-                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/50 flex items-center gap-2">
-                   <TrendingUp className="h-3 w-3" /> Sumber Supplier
-                </p>
-                <div className="p-5 rounded-3xl bg-primary/[0.03] dark:bg-primary/[0.05] border border-primary/10 group cursor-default transition-all hover:bg-primary/[0.06] shadow-sm">
-                   <p className="text-[9px] font-black text-primary/60 uppercase tracking-[0.2em] mb-1.5">Latest Purchase From:</p>
-                   <p className="text-lg font-black text-foreground group-hover:text-primary transition-colors tracking-tight">
-                     {product.latestSupplier?.name || "Belum Ada Pembelian"}
-                   </p>
-                </div>
-              </div>
-
-              <div className="space-y-4">
-                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/50">Deskripsi Produk</p>
-                <div className="relative">
-                  <div className="absolute -left-3 top-0 h-full w-1 bg-primary/10 rounded-full" />
-                  <p className="text-sm text-foreground/80 leading-relaxed font-semibold italic pl-2">
-                    &quot;{product.description || 'Tidak ada deskripsi tersedia untuk produk ini.'}&quot;
-                  </p>
-                </div>
-              </div>
-              
-              <div className="space-y-4 pt-2">
-                <p className="text-[10px] font-black uppercase tracking-[0.25em] text-muted-foreground/50">Profile Rasa</p>
-                <div className="flex flex-wrap gap-2.5">
-                  {product.taste.map((t: EnumTaste, idx: number) => (
-                    <Badge key={idx} variant="secondary" className="font-black text-[9px] uppercase tracking-widest px-4 py-1.5 bg-gray-100 dark:bg-gray-800/80 text-foreground/70 border-none rounded-xl shadow-sm hover:scale-105 transition-transform">
-                      {t}
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Quick Analytics */}
-          <div className="grid grid-cols-1 gap-4">
-             <Card className="border-none shadow-2xl shadow-indigo-500/10 bg-gradient-to-br from-indigo-500 to-indigo-700 dark:from-indigo-600 dark:to-indigo-900 rounded-[2.5rem] overflow-hidden relative group">
-                <div className="absolute right-[-10%] top-[-10%] p-4 opacity-10 group-hover:scale-125 transition-transform duration-1000">
-                   <TrendingUp className="h-40 w-40 text-white" />
-                </div>
-                <CardContent className="p-10 flex flex-col justify-between relative z-10 min-h-[180px]">
-                  <div className="space-y-2">
-                    <p className="text-[10px] font-black text-indigo-100/60 uppercase tracking-[0.3em]">Stock Inventory</p>
-                    <p className="text-5xl font-black text-white tracking-tighter">
-                      {product.stockQty?.toLocaleString('id-ID') || 0}
-                      <span className="text-[10px] ml-2 opacity-60 uppercase tracking-widest font-black">Total Pcs</span>
-                    </p>
-                  </div>
-                  <div className="mt-4">
-                    <Badge className="font-black text-[9px] uppercase tracking-[0.2em] bg-white/20 text-white backdrop-blur-md px-4 py-2 rounded-xl border-none shadow-xl">
-                      Live Inventory Status
-                    </Badge>
-                  </div>
-                </CardContent>
-             </Card>
-          </div>
+        {/* Right Column - Image & Insights */}
+        <div className="space-y-6">
+          <ProductImageGallery images={images} productName={product.name} />
+          <ProductInsightsCard product={product} />
+          <ProductStockCard product={product} />
         </div>
       </div>
     </div>

--- a/src/components/dashboard/products/VariantCreateDialog.tsx
+++ b/src/components/dashboard/products/VariantCreateDialog.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Plus, Loader2, Package } from "lucide-react";
+import { api, PackageType } from "@/lib/api";
+import { toast } from "sonner";
+
+const PACKAGE_OPTIONS: { value: PackageType; label: string }[] = [
+  { value: "Small", label: "Small" },
+  { value: "Medium", label: "Medium" },
+  { value: "250gr", label: "250gr" },
+  { value: "500gr", label: "500gr" },
+  { value: "1kg", label: "1kg" },
+  { value: "bal", label: "Bal" },
+];
+
+const variantSchema = z.object({
+  package: z.enum(["Small", "Medium", "250gr", "500gr", "1kg", "bal"], {
+    message: "Pilih packaging varian",
+  }),
+  price: z.string().refine((val) => !isNaN(Number(val)) && Number(val) >= 0, {
+    message: "Harga tidak boleh negatif",
+  }),
+  initialStock: z.string().optional(),
+  sizeInGram: z.string().optional(),
+});
+
+type VariantFormValues = z.infer<typeof variantSchema>;
+
+interface VariantCreateDialogProps {
+  productId: string;
+  onSuccess: () => void;
+}
+
+export function VariantCreateDialog({ productId, onSuccess }: VariantCreateDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    getValues,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<VariantFormValues>({
+    resolver: zodResolver(variantSchema),
+    defaultValues: {
+      package: "Small" as PackageType,
+      price: "",
+      initialStock: "",
+      sizeInGram: "",
+    },
+  });
+
+  const selectedPackage = getValues("package");
+
+  const onSubmit = async (data: VariantFormValues) => {
+    try {
+      await api.products.createVariant(productId, {
+        package: data.package,
+        price: Number(data.price),
+        initialStock: data.initialStock ? Number(data.initialStock) : 0,
+        sizeInGram: data.sizeInGram ? Number(data.sizeInGram) : undefined,
+      });
+
+      toast.success("Varian berhasil ditambahkan");
+      setOpen(false);
+      reset();
+      onSuccess();
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Gagal menambahkan varian";
+      toast.error(message);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)} className="gap-2">
+        <Plus className="h-4 w-4" />
+        Add Variant
+      </Button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              <Package className="h-5 w-5" />
+              Add Product Variant
+            </DialogTitle>
+            <DialogDescription>
+              Add a new packaging variant to this product.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+            <div className="space-y-2">
+              <Label htmlFor="package">Packaging</Label>
+              <Select
+                value={selectedPackage}
+                onValueChange={(value) =>
+                  setValue("package", value as PackageType)
+                }
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select packaging..." />
+                </SelectTrigger>
+                <SelectContent>
+                  {PACKAGE_OPTIONS.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {errors.package && (
+                <p className="text-xs text-red-500">{errors.package.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="price">Selling Price</Label>
+              <Input
+                id="price"
+                type="number"
+                placeholder="25000"
+                {...register("price")}
+                className={errors.price ? "border-red-500" : ""}
+              />
+              {errors.price && (
+                <p className="text-xs text-red-500">{errors.price.message}</p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="initialStock">Initial Stock</Label>
+              <Input
+                id="initialStock"
+                type="number"
+                placeholder="0"
+                {...register("initialStock")}
+              />
+              {errors.initialStock && (
+                <p className="text-xs text-red-500">
+                  {errors.initialStock.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="sizeInGram">Size (grams)</Label>
+              <Input
+                id="sizeInGram"
+                type="number"
+                placeholder="250"
+                {...register("sizeInGram")}
+              />
+              {errors.sizeInGram && (
+                <p className="text-xs text-red-500">
+                  {errors.sizeInGram.message}
+                </p>
+              )}
+            </div>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Adding...
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4" />
+                    Add Variant
+                  </>
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -182,6 +182,16 @@ export interface CreateSupplierDto {
 
 export type UpdateSupplierDto = Partial<CreateSupplierDto>;
 
+export type PackageType = 'Medium' | 'Small' | '250gr' | '500gr' | '1kg' | 'bal';
+
+export interface CreateVariantDto {
+  package: PackageType;
+  price: number;
+  initialStock?: number;
+  sku?: string;
+  sizeInGram?: number;
+}
+
 export const api = {
   get: <T>(endpoint: string, options: RequestInit = {}) => 
     fetchApi<T>(endpoint, { ...options, method: 'GET' }),
@@ -218,6 +228,7 @@ export const api = {
     getBrands: () => api.get<Brand[]>('/products/brands'),
     createBrand: (name: string) => api.post<Brand>('/products/brands', { name }),
     create: (data: Record<string, unknown>) => api.post<Record<string, unknown>>('/products', data),
+    createVariant: (productId: string, data: CreateVariantDto) => api.post<Record<string, unknown>>(`/products/${productId}/variants`, data),
   },
 
   pricingRules: {


### PR DESCRIPTION
## Summary

- **Add Variant dialog**: Created `VariantCreateDialog` component using `react-hook-form` + `zod` validation with fields for Packaging, Selling Price, Initial Stock, and Size
- **API integration**: Added `api.products.createVariant()` method calling new `POST /products/:id/variants` endpoint
- **UX improvement**: Replaced non-functional placeholder button with working dialog that auto-refreshes product data on success
- **Layout redesign**: Replaced tab switcher with stacked sections — Variants table and Stock History are now always visible (zero clicks needed)

## Related

- Backend PR: https://github.com/mamuncloud/pns-server/pull/new/feat/add-variant-endpoint
- Closes #21

## Files Changed

| File | Change |
|------|--------|
| `src/app/(dashboard)/dashboard/products/[id]/page.tsx` | Wired up dialog, replaced tabs with stacked layout |
| `src/lib/api.ts` | Added `createVariant()` method and `CreateVariantDto` type |
| `src/components/dashboard/products/VariantCreateDialog.tsx` | **New** — dialog component with form validation |

## Screenshots

The Add Variant button now opens a dialog with:
- Packaging selector (Small, Medium, 250gr, 500gr, 1kg, bal)
- Selling Price input
- Initial Stock input (optional, defaults to 0)
- Size in grams input (optional)

After submission, the product detail page automatically refreshes to show the new variant in the table.