### PR TITLE
refactor(dashboard): remove notification and profile dropdown from header

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -74,7 +74,6 @@ export default function DashboardLayout({
       <div className="flex flex-1 flex-col min-w-0">
         {/* Header */}
         <DashboardHeader
-          user={user}
           onMobileToggle={() => setIsMobileSidebarOpen(!isMobileSidebarOpen)}
         />
 

--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,33 +1,18 @@
 "use client";
 
-import { useAuth } from "@/hooks/use-auth";
-import { AuthUser } from "@/types/financial";
-import {
-  Bell,
-  User,
-  LogOut,
-  ChevronDown,
-  Settings,
-  HelpCircle,
-  Menu,
-} from "lucide-react";
+import { Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
 import { usePathname } from "next/navigation";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 interface DashboardHeaderProps {
-  user: AuthUser | null;
   onMobileToggle?: () => void;
 }
 
 export default function DashboardHeader({
-  user,
   onMobileToggle,
 }: DashboardHeaderProps) {
-  const { logout } = useAuth();
   const pathname = usePathname();
-  const [showProfileMenu, setShowProfileMenu] = useState(false);
 
   // Derive page title from pathname
   const getPageTitle = () => {
@@ -85,78 +70,6 @@ export default function DashboardHeader({
       <div className="flex items-center gap-6">
         {/* Theme Toggle */}
         <ThemeToggle />
-
-        {/* Notifications */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground relative"
-        >
-          <Bell className="h-5 w-5" />
-          <span className="absolute top-2 right-2 w-2.5 h-2.5 bg-primary rounded-full border-2 border-white dark:border-gray-900 shadow-sm" />
-        </Button>
-
-        {/* User Profile */}
-        <div className="relative">
-          <button
-            onClick={() => setShowProfileMenu(!showProfileMenu)}
-            className="flex items-center gap-2 pl-2 pr-1 py-1 rounded-full hover:bg-gray-100 transition-all dark:hover:bg-gray-800"
-          >
-            <div className="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center text-primary dark:text-primary-foreground font-bold text-sm">
-              {user?.name?.charAt(0) || user?.email?.charAt(0) || "U"}
-            </div>
-            <div className="hidden sm:block text-left">
-              <p className="text-sm font-semibold text-foreground leading-none">
-                {user?.name || "Staff Member"}
-              </p>
-              <p className="text-xs text-muted-foreground mt-0.5 uppercase tracking-tighter">
-                {user?.role || "Staff"}
-              </p>
-            </div>
-            <ChevronDown className="h-4 w-4 text-muted-foreground ml-1" />
-          </button>
-
-          {/* User Dropdown */}
-          {showProfileMenu && (
-            <>
-              <div
-                className="fixed inset-0 z-40"
-                onClick={() => setShowProfileMenu(false)}
-              />
-              <div className="absolute right-0 mt-2 w-56 bg-white border border-gray-200 rounded-xl shadow-xl z-50 py-2 dark:bg-gray-900 dark:border-gray-800">
-                <div className="px-4 py-2 border-b border-gray-100 dark:border-gray-800">
-                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                    Signed in as
-                  </p>
-                  <p className="text-sm font-semibold truncate mt-0.5">
-                    {user?.email}
-                  </p>
-                </div>
-
-                <div className="py-1">
-                  <button className="w-full flex items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-gray-50 dark:hover:bg-gray-800">
-                    <User className="h-4 w-4" /> Profile
-                  </button>
-                  <button className="w-full flex items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-gray-50 dark:hover:bg-gray-800">
-                    <Settings className="h-4 w-4" /> Settings
-                  </button>
-                  <button className="w-full flex items-center gap-3 px-4 py-2 text-sm text-foreground hover:bg-gray-50 dark:hover:bg-gray-800">
-                    <HelpCircle className="h-4 w-4" /> Help Center
-                  </button>
-                </div>
-
-                <div className="pt-1 border-t border-gray-100 dark:border-gray-800">
-                  <button
-                    onClick={logout}
-                    className="w-full flex items-center gap-3 px-4 py-2 text-sm text-destructive hover:bg-destructive/5 dark:hover:bg-destructive/10"
-                  >
-                    <LogOut className="h-4 w-4" /> Logout
-                  </button>
-                </div>
-              </div>
-            </>
-          )}
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
Closes #59. This PR simplifies the dashboard header by removing the notification button and the user profile dropdown (avatar, name, role) as requested. All unused state, props, and imports have been cleaned up.