### PR TITLE
fix(components): improve dark mode contrast for variant badges

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -74,7 +74,7 @@ export default function ProductCard({
           {product.variants.map((v, index) => (
             <span 
               key={`${v.package}-${index}`} 
-              className="px-3 py-1.5 bg-primary/10 rounded-full text-[10px] font-bold text-primary dark:text-primary-foreground/90"
+              className="px-3 py-1.5 bg-primary/10 dark:bg-primary/20 rounded-full text-[10px] font-bold text-primary dark:text-primary"
             >
               {v.package}
             </span>


### PR DESCRIPTION
## Summary
Fix unreadable variant package badges in `ProductCard` when dark mode is enabled.

## Problem
The rounded pill badges (e.g. `Small`, `Medium`, `Large`) had:
- Nearly invisible background (`bg-primary/10` → 10% yellow on dark card)
- Dark/black text (`dark:text-primary-foreground/90` → `oklch(0.205)`) — zero contrast

## Changes
- `dark:text-primary-foreground/90` → `dark:text-primary` — uses visible yellow (`#FFD700`) text
- Added `dark:bg-primary/20` — slightly stronger background for the pill shape

## File Changed
- `src/components/ProductCard.tsx` (line 77)

Closes #65