### PR TITLE
[CLEANUP(web)] remove pricing logic

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,7 +6,6 @@ declare global {
 
 import { 
   AuthUser, 
-  PricingRule, 
   StockAdjustment, 
   Purchase,
   CreatePurchaseDto,
@@ -229,7 +228,6 @@ export const api = {
       if (search) qs.append('search', search);
       return api.get<unknown>(`/products?${qs.toString()}`);
     },
-    getPricing: (id: string) => api.get<PricingRule[]>(`/products/${id}/pricing`),
     getBrands: (search?: string) => api.get<Brand[]>(`/products/brands${search ? `?search=${encodeURIComponent(search)}` : ''}`),
     createBrand: (name: string) => api.post<Brand>('/products/brands', { name }),
     create: (data: Record<string, unknown>) => api.post<Record<string, unknown>>('/products', data),
@@ -237,9 +235,7 @@ export const api = {
     createVariant: (productId: string, data: CreateVariantDto) => api.post<Record<string, unknown>>(`/products/${productId}/variants`, data),
   },
 
-  pricingRules: {
-    create: (data: Partial<PricingRule>) => api.post<PricingRule>('/pricing-rules', data),
-  },
+
 
   stockAdjustments: {
     list: (productId?: string) => api.get<StockAdjustment[]>(`/stock-adjustments${productId ? `?productId=${productId}` : ''}`),

--- a/src/lib/products-db.ts
+++ b/src/lib/products-db.ts
@@ -29,6 +29,7 @@ interface BackendProduct {
   status?: string;
   currentHpp?: number;
   createdAt: string;
+
   updatedAt: string;
   variants: Array<{
     id: string;
@@ -93,6 +94,7 @@ export async function getProductById(id: string): Promise<Product | null> {
       createdAt: p.createdAt,
       updatedAt: p.updatedAt,
     };
+
   } catch (error) {
     console.error(`Error in getProductById for ${id}:`, error);
     return null;

--- a/src/types/financial.ts
+++ b/src/types/financial.ts
@@ -1,16 +1,3 @@
-export type PricingType = 'WEIGHT' | 'FIXED_PRICE' | 'BULK';
-
-export interface PricingRule {
-  id: string;
-  productId: string;
-  type: PricingType;
-  weightGram?: number;
-  targetPrice?: number;
-  marginPct: number;
-  rounding: number;
-  createdAt: string;
-  updatedAt: string;
-}
 
 export type AdjustmentReason = 'DEFECT' | 'EXPIRED' | 'LOST' | 'RESTOCK' | 'PURCHASE';
 
@@ -200,7 +187,6 @@ export interface OrderItem {
   id: string;
   orderId: string;
   productVariantId: string;
-  pricingRuleId?: string;
   quantity: number;
   price: number;
   productVariant?: {
@@ -233,6 +219,5 @@ export interface CreateOrderDto {
     productVariantId: string;
     quantity: number;
     price: number;
-    pricingRuleId?: string;
   }[];
 }


### PR DESCRIPTION
Connected to #71.

This PR removes all pricing rule logic, components, and related fields from pns-web as this logic is moving to a separate microservice.

### Verification
- [x] Deleted PricingRuleCreateDialog component
- [x] Removed PricingRule interface and types
- [x] Cleaned up API client methods and state
- [x] Build successfully