### PR TITLE
[FEAT(web)] Disable ordering and carting when store is closed

### DIFF
--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -13,11 +13,13 @@ import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { CreateOrderDto } from "@/types/financial";
 import Link from "next/link";
-import { Order } from "@/types/financial";
+import { useStoreSettings } from "@/hooks/use-store-settings";
+import { AlertCircle } from "lucide-react";
 
 export default function CheckoutPage() {
   const router = useRouter();
   const { items, totalPrice, removeFromCart, updateQuantity, clearCart } = useCart();
+  const { isStoreOpen } = useStoreSettings();
   const [isProcessing, setIsProcessing] = useState(false);
   const [isLookingUp, setIsLookingUp] = useState(false);
   const [customerFound, setCustomerFound] = useState(false);
@@ -191,6 +193,16 @@ export default function CheckoutPage() {
             <div className="sticky top-24 bg-white dark:bg-zinc-900/50 rounded-3xl p-6 border border-zinc-100 dark:border-zinc-800 shadow-xl shadow-zinc-200/50 dark:shadow-none">
               <h2 className="text-xl font-bold text-dark dark:text-white mb-6">Detail Pengambilan</h2>
 
+              {!isStoreOpen && (
+                <div className="mb-6 p-4 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-900/50 rounded-2xl flex gap-3 text-red-600 dark:text-red-400">
+                  <AlertCircle className="h-5 w-5 shrink-0" />
+                  <div className="text-sm">
+                    <p className="font-bold mb-1">Toko Sedang Tutup</p>
+                    <p className="opacity-90">Maaf, kami tidak menerima pesanan saat ini. Silakan coba lagi nanti.</p>
+                  </div>
+                </div>
+              )}
+
               <form onSubmit={handleCheckout} className="space-y-6">
                 <div className="space-y-4">
                   {/* Phone first — required */}
@@ -257,8 +269,8 @@ export default function CheckoutPage() {
 
                 <Button
                   type="submit"
-                  disabled={isProcessing}
-                  className="w-full h-14 rounded-2xl bg-primary hover:bg-primary/90 text-white font-bold text-lg flex items-center justify-center gap-2 shadow-lg shadow-primary/20 transition-all hover:scale-[1.02] disabled:hover:scale-100"
+                  disabled={isProcessing || !isStoreOpen}
+                  className="w-full h-14 rounded-2xl bg-primary hover:bg-primary/90 text-white font-bold text-lg flex items-center justify-center gap-2 shadow-lg shadow-primary/20 transition-all hover:scale-[1.02] disabled:hover:scale-100 disabled:bg-zinc-400 dark:disabled:bg-zinc-800 disabled:shadow-none"
                 >
                   {isProcessing ? (
                     <>

--- a/src/app/products/[id]/ProductOrderClient.tsx
+++ b/src/app/products/[id]/ProductOrderClient.tsx
@@ -7,10 +7,12 @@ import { formatCurrency, formatWeight } from "@/lib/utils";
 import { ShoppingCart, Zap } from "lucide-react";
 import { useCart } from "@/contexts/CartContext";
 import { useRouter } from "next/navigation";
+import { useStoreSettings } from "@/hooks/use-store-settings";
 
 export default function ProductOrderClient({ product }: { product: Product }) {
   const router = useRouter();
   const { addToCart } = useCart();
+  const { isStoreOpen } = useStoreSettings();
   
   const sortedVariants = [...product.variants].sort((a, b) => a.price - b.price);
   const [selectedVariantId, setSelectedVariantId] = useState<string | null>(
@@ -101,9 +103,9 @@ export default function ProductOrderClient({ product }: { product: Product }) {
       <div className="flex flex-col sm:flex-row gap-3 pt-4 border-t border-on-background/5 dark:border-zinc-800">
         <Button 
           onClick={handleAddToCart}
-          disabled={!selectedVariant || selectedVariant.stock === 0}
+          disabled={!selectedVariant || selectedVariant.stock === 0 || !isStoreOpen}
           variant="outline"
-          className="w-full sm:w-1/2 h-14 md:h-16 rounded-2xl border-2 border-primary text-primary hover:bg-primary/5 font-bold transition-all duration-300 hover:scale-[1.02] flex items-center justify-center gap-2 text-base"
+          className="w-full sm:w-1/2 h-14 md:h-16 rounded-2xl border-2 border-primary text-primary hover:bg-primary/5 font-bold transition-all duration-300 hover:scale-[1.02] flex items-center justify-center gap-2 text-base disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <ShoppingCart className="h-5 w-5" />
           Masukkan Keranjang
@@ -111,13 +113,19 @@ export default function ProductOrderClient({ product }: { product: Product }) {
         
         <Button 
           onClick={handleDirectBuy}
-          disabled={!selectedVariant || selectedVariant.stock === 0}
-          className="w-full sm:w-1/2 h-14 md:h-16 rounded-2xl bg-primary hover:bg-primary/90 text-white font-bold transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/20 flex items-center justify-center gap-2 text-base"
+          disabled={!selectedVariant || selectedVariant.stock === 0 || !isStoreOpen}
+          className="w-full sm:w-1/2 h-14 md:h-16 rounded-2xl bg-primary hover:bg-primary/90 text-white font-bold transition-all duration-300 hover:scale-[1.02] hover:shadow-lg hover:shadow-primary/20 flex items-center justify-center gap-2 text-base disabled:bg-zinc-400 disabled:shadow-none disabled:cursor-not-allowed"
         >
           <Zap className="h-5 w-5" />
           Beli Langsung
         </Button>
       </div>
+
+      {!isStoreOpen && (
+        <p className="text-center text-destructive font-bold text-sm bg-destructive/5 py-3 rounded-xl border border-destructive/10">
+          Toko sedang tutup. Pemesanan sementara tidak tersedia.
+        </p>
+      )}
     </div>
   );
 }

--- a/src/components/FloatingCart.tsx
+++ b/src/components/FloatingCart.tsx
@@ -5,13 +5,15 @@ import { formatCurrency } from "@/lib/utils";
 import { ShoppingCart, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useStoreSettings } from "@/hooks/use-store-settings";
 
 export default function FloatingCart() {
   const { totalItems, totalPrice } = useCart();
+  const { isStoreOpen } = useStoreSettings();
   const pathname = usePathname();
 
-  // Hide the floating cart on the checkout pages to prevent distraction
-  if (totalItems === 0 || pathname.startsWith("/checkout")) return null;
+  // Hide the floating cart on the checkout pages or when store is closed to prevent distraction
+  if (totalItems === 0 || pathname.startsWith("/checkout") || !isStoreOpen) return null;
 
   return (
     <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-6 md:w-80 z-50 animate-in slide-in-from-bottom-5 duration-300">

--- a/src/components/checkout/PaymentModal.tsx
+++ b/src/components/checkout/PaymentModal.tsx
@@ -78,7 +78,7 @@ export function PaymentModal({ orderId, paymentUrl, isOpen, onClose }: PaymentMo
                 <Loader2 className="w-10 h-10 animate-spin text-primary mb-4" />
                 <p className="text-sm font-medium text-zinc-600 dark:text-zinc-400">Memuat Sesi Pembayaran...</p>
                 <p className="text-xs text-zinc-400 max-w-[200px] text-center mt-2">
-                    Jika tidak muncul, klik tombol "Buka di Tab Baru" di atas.
+                    Jika tidak muncul, klik tombol &quot;Buka di Tab Baru&quot; di atas.
                 </p>
             </div>
           )}


### PR DESCRIPTION
## Summary
This PR updates the frontend to correctly handle the store closed status. It disables all ordering actions and hides the cart to prevent frustrated user experiences when the backend would otherwise reject the order.

Closes #40 in mamuncloud/pns-server (referenced manually)

## Changes
- **Product Page**: Disabled 'Add to Cart' and 'Buy Direct' buttons when store is closed. Added visual warning.
- **Checkout Page**: Disabled 'Pay' button and added a warning banner.
- **Components**: Hidden the Floating Cart when store is closed.
- **Hooks**: Integrated `useStoreSettings` across components.

## Verification
- Toggled store status.
- Verified buttons are disabled and warnings are visible.
- Verified Floating Cart disappears when store toggled to closed.
