### PR TITLE
fix(components): wrap FloatingCart and Toaster in ClientOnly

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,6 +20,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { ThemeProvider } from "@/components/theme-provider";
 import { CartProvider } from "@/contexts/CartContext";
 import FloatingCart from "@/components/FloatingCart";
+import { ClientOnly } from "@/components/ClientOnly";
 
 export default function RootLayout({
   children,
@@ -45,8 +46,10 @@ export default function RootLayout({
         >
           <CartProvider>
             {children}
-            <FloatingCart />
-            <Toaster />
+            <ClientOnly>
+              <FloatingCart />
+              <Toaster />
+            </ClientOnly>
           </CartProvider>
         </ThemeProvider>
       </body>

--- a/src/components/ClientOnly.tsx
+++ b/src/components/ClientOnly.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useSyncExternalStore } from "react"
+
+function subscribe() {
+  return () => {}
+}
+
+function getSnapshot() {
+  return true
+}
+
+function getServerSnapshot() {
+  return false
+}
+
+export function ClientOnly({
+  children,
+  fallback = null,
+}: {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}) {
+  const isMounted = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  if (!isMounted) return <>{fallback}</>
+  return <>{children}</>
+}


### PR DESCRIPTION
## Summary

- Create `ClientOnly` wrapper component using `useSyncExternalStore` for React 19 compliance
- Wrap `FloatingCart` and `Toaster` in `ClientOnly` to prevent SSR rendering
- Fixes hydration mismatch error on all routes

## Changes

- **src/components/ClientOnly.tsx** (new): Client-only wrapper component
- **src/app/layout.tsx**: Wrap FloatingCart and Toaster in ClientOnly

## Testing

- [x] Lint passes
- [x] Hydration error resolved
- [x] Cart functionality works correctly

Closes #110