### PR TITLE
feat(web): integrate strict wholesale package filtering in products page

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -11,11 +11,12 @@ export const metadata = {
 };
 
 export default async function ProductsPage(props: {
-  searchParams: Promise<{ page?: string; tab?: string }>;
+  searchParams: Promise<{ page?: string; tab?: string; package?: string }>;
 }) {
   const searchParams = await props.searchParams;
   const page = Number(searchParams.page) || 1;
   const activeTab = searchParams.tab || "semua";
+  const packageFilter = searchParams.package;
   
   // Map tab to taste filter for backend
   const tasteMap: Record<string, string | undefined> = {
@@ -28,7 +29,7 @@ export default async function ProductsPage(props: {
   const tasteFilter = tasteMap[activeTab];
   
   // Fetch paginated products from DB - request only items that have stock
-  const { data: products, meta } = await getProductsFromDb(page, 12, tasteFilter, undefined, true);
+  const { data: products, meta } = await getProductsFromDb(page, 12, tasteFilter, undefined, true, undefined, 'desc', undefined, packageFilter);
 
   return (
     <>

--- a/src/components/Wholesale.tsx
+++ b/src/components/Wholesale.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "./ui/button";
 import { PackageOpen, ArrowRight, Sparkles } from "lucide-react";
+import Link from "next/link";
 
 export default function Wholesale() {
   return (
@@ -30,13 +31,15 @@ export default function Wholesale() {
             </p>
             
             <div className="pt-4">
-              <Button className="group/btn relative h-16 px-10 overflow-hidden rounded-2xl bg-primary font-black uppercase tracking-widest text-sm italic transition-all duration-500 hover:shadow-primary/50 hover:scale-[1.05] active:scale-[0.98] border border-white/10 text-primary-foreground">
-                <div className="absolute inset-0 bg-gradient-to-tr from-white/20 via-transparent to-transparent opacity-0 group-hover/btn:opacity-100 transition-opacity duration-500" />
-                <div className="relative flex items-center justify-center gap-3">
-                  Pesan Grosir Sekarang
-                  <ArrowRight className="h-5 w-5 transition-transform duration-500 group-hover/btn:translate-x-1" />
-                </div>
-              </Button>
+              <Link href="/products?package=bal">
+                <Button className="group/btn relative h-16 px-10 overflow-hidden rounded-2xl bg-primary font-black uppercase tracking-widest text-sm italic transition-all duration-500 hover:shadow-primary/50 hover:scale-[1.05] active:scale-[0.98] border border-white/10 text-primary-foreground">
+                  <div className="absolute inset-0 bg-gradient-to-tr from-white/20 via-transparent to-transparent opacity-0 group-hover/btn:opacity-100 transition-opacity duration-500" />
+                  <div className="relative flex items-center justify-center gap-3">
+                    Pesan Grosir Sekarang
+                    <ArrowRight className="h-5 w-5 transition-transform duration-500 group-hover/btn:translate-x-1" />
+                  </div>
+                </Button>
+              </Link>
             </div>
           </div>
 

--- a/src/lib/products-db.ts
+++ b/src/lib/products-db.ts
@@ -103,7 +103,7 @@ export async function getProductById(id: string): Promise<Product | null> {
   }
 }
 
-export async function getProductsFromDb(page: number = 1, limit: number = 12, taste?: string, search?: string, hasStock?: boolean, sortBy?: string, sortOrder: 'asc' | 'desc' = 'desc', eventId?: string): Promise<PaginatedProducts> {
+export async function getProductsFromDb(page: number = 1, limit: number = 12, taste?: string, search?: string, hasStock?: boolean, sortBy?: string, sortOrder: 'asc' | 'desc' = 'desc', eventId?: string, packageLabel?: string): Promise<PaginatedProducts> {
   try {
     let url = `/products?page=${page}&limit=${limit}`;
     if (taste && taste !== "Semua") url += `&taste=${taste}`;
@@ -112,6 +112,7 @@ export async function getProductsFromDb(page: number = 1, limit: number = 12, ta
     if (sortBy) url += `&sortBy=${sortBy}`;
     if (sortOrder) url += `&sortOrder=${sortOrder}`;
     if (eventId) url += `&eventId=${eventId}`;
+    if (packageLabel) url += `&package=${packageLabel}`;
 
     const response = await api.get<BackendProduct[]>(url);
     


### PR DESCRIPTION
## Description
This PR integrates the new strict package filtering capability in the frontend.
- Adds `package` support to `getProductsFromDb`.
- Updates the products page to handle the `package` search parameter.
- Updates the Wholesale component link to `/products?package=bal`.

Closes #134